### PR TITLE
fix: Correct spelling of GitHub

### DIFF
--- a/src/components/appBar/Infobar.jsx
+++ b/src/components/appBar/Infobar.jsx
@@ -168,7 +168,7 @@ const InfoBar = () => {
 					<span>Unverified Assets</span>
 					<Switch color="secondary" checked={valueVerified} onChange={onChangeType} />
 					<a className={classes.link} href="https://github.com/osmosis-labs" target="_blank">
-						Github
+						GitHub
 					</a>
 					<a className={classes.link} href="https://app.osmosis.zone/" target="_blank">
 						App


### PR DESCRIPTION
It is correct to capitalize the H in GitHub's brand name.